### PR TITLE
Update i2c master for faster scl

### DIFF
--- a/modules/i2c/src/i2c_master.c
+++ b/modules/i2c/src/i2c_master.c
@@ -1,4 +1,4 @@
-// Copyright 2021 XMOS LIMITED.
+// Copyright 2021-2022 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <stdlib.h>
 #include <stdint.h>
@@ -26,7 +26,7 @@ extern i2c_regop_res_t write_reg16(i2c_master_t *ctx, uint8_t device_addr, uint1
 #define BIT_TIME(KBITS_PER_SEC) ((XS1_TIMER_MHZ * 1000) / KBITS_PER_SEC)
 #define BIT_MASK(BIT_POS) (1 << BIT_POS)
 
-#define JITTER_TICKS    3
+#define JITTER_TICKS    0
 #define WAKEUP_TICKS    20
 
 static uint32_t interrupt_state_get(void)

--- a/test/lib_i2c/i2c_master_reg_test/src/main.c
+++ b/test/lib_i2c/i2c_master_reg_test/src/main.c
@@ -48,8 +48,6 @@ void test() {
             p_sda, 0, 0,
             400); /* kbps */
 
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
-
     // Test register writing
     write_results[TEST_WRITE_1] = write_reg(i2c_ctx_ptr, 0x44, 0x07, 0x12);
     write_results[TEST_WRITE_2] = write_reg8_addr16(i2c_ctx_ptr, 0x22, 0xfe99, 0x12);
@@ -79,7 +77,6 @@ void test() {
 DECLARE_JOB(burn, (void));
 
 void burn(void) {
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
     for(;;);
 }
 

--- a/test/lib_i2c/i2c_master_test/src/main.c
+++ b/test/lib_i2c/i2c_master_test/src/main.c
@@ -102,8 +102,6 @@ void test() {
             p_sda, p_sda_bit_pos, 0,
             SPEED); /* kbps */
 
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
-
     // Setup all data to be written
     data_write_1[0] = 0x90; data_write_1[1] = 0xfe;
     data_write_2[0] = 0xff; data_write_2[1] = 0x00; data_write_2[2] = 0xaa;
@@ -142,7 +140,6 @@ void test() {
 DECLARE_JOB(burn, (void));
 
 void burn(void) {
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
     for(;;);
 }
 

--- a/test/lib_i2c/i2c_slave_test/src/main.c
+++ b/test/lib_i2c/i2c_slave_test/src/main.c
@@ -75,7 +75,6 @@ int i2c_shutdown(void *app_data) {
 DECLARE_JOB(burn, (void));
 
 void burn(void) {
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
     for(;;);
 }
 

--- a/test/lib_i2c/i2c_test_locks/src/main.c
+++ b/test/lib_i2c/i2c_test_locks/src/main.c
@@ -31,7 +31,6 @@ void test() {
             p_sda, 0, 0,
             400); /* kbps */
 
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
     i2c_master_write(i2c_ctx_ptr, 0x33, data, 1, NULL, 0);
     hwtimer_delay(delay_timer, 1000);
     i2c_master_write(i2c_ctx_ptr, 0x33, data, 1, NULL, 1);
@@ -44,7 +43,6 @@ void test() {
 DECLARE_JOB(burn, (void));
 
 void burn(void) {
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
     for(;;);
 }
 

--- a/test/lib_i2c/i2c_test_repeated_start/src/main.c
+++ b/test/lib_i2c/i2c_test_repeated_start/src/main.c
@@ -30,8 +30,6 @@ void test() {
             p_sda, 0, 0,
             400); /* kbps */
 
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
-
     i2c_master_write(i2c_ctx_ptr, 0x33, data, 1, NULL, 0);
     i2c_master_write(i2c_ctx_ptr, 0x33, data, 1, NULL, 1);
 
@@ -42,7 +40,6 @@ void test() {
 DECLARE_JOB(burn, (void));
 
 void burn(void) {
-    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
     for(;;);
 }
 


### PR DESCRIPTION
While investigating the period of SCL being slower than desired, it was
found that the JITTER_TICKS carry over from the legacy implementation
does not appear to be required anymore.  This commit sets JITTER_TICKS
to 0.  This implementation was verified via xsim tests and viewed on a
scope to meet i2c specification timings.

Closes #6 
It was confirmed that the SCL freq is not related to xmos/xcore_sdk#491.

Testing with an XCORE-EXPLORER-AI, I measured a period of 2.64us, thus 378.8kHz when set for 400kHz.  This commit now has a period of 2.56us, thus 390.6kHz.

It is worth noting that the previous version was still within I2C specification, as 400kHz is the maximum frequency, not required frequency.