### PR TITLE
Feature/configurable spi thread mode

### DIFF
--- a/modules/spi/api/spi.h
+++ b/modules/spi/api/spi.h
@@ -92,7 +92,7 @@ typedef enum {
  * Set SPI Slave thread to high priority
  */
 #ifndef HIL_IO_SPI_SLAVE_HIGH_PRIO
-    #define HIL_IO_SPI_SLAVE_HIGH_PRIO 1
+    #define HIL_IO_SPI_SLAVE_HIGH_PRIO 0
 #endif
 
 /**

--- a/modules/spi/api/spi.h
+++ b/modules/spi/api/spi.h
@@ -89,6 +89,20 @@ typedef enum {
 #define SPI_MODE_3 1,1
 
 /**
+ * Set SPI Slave thread to high priority
+ */
+#ifndef HIL_IO_SPI_SLAVE_HIGH_PRIO
+    #define HIL_IO_SPI_SLAVE_HIGH_PRIO 1
+#endif
+
+/**
+ * Set SPI Slave thread to run in fast mode
+ */
+#ifndef HIL_IO_SPI_SLAVE_FAST_MODE
+    #define HIL_IO_SPI_SLAVE_FAST_MODE 1
+#endif
+
+/**
  * Struct to hold a SPI master context.
  *
  * The members in this struct should not be accessed directly.

--- a/modules/spi/src/spi_slave.c
+++ b/modules/spi/src/spi_slave.c
@@ -279,7 +279,7 @@ void spi_slave(
     uint32_t out_word;
 
 	/* Enable fast mode and high priority */
-    local_thread_mode_set_bits(thread_mode_fast);
+    local_thread_mode_set_bits(thread_mode_high_priority);
 
     /* Setup the chip select port */
     port_enable(p_cs);

--- a/modules/spi/src/spi_slave.c
+++ b/modules/spi/src/spi_slave.c
@@ -279,7 +279,7 @@ void spi_slave(
     uint32_t out_word;
 
 	/* Enable fast mode and high priority */
-    local_thread_mode_set_bits(thread_mode_fast | thread_mode_high_priority);
+    local_thread_mode_set_bits(thread_mode_fast);
 
     /* Setup the chip select port */
     port_enable(p_cs);

--- a/modules/spi/src/spi_slave.c
+++ b/modules/spi/src/spi_slave.c
@@ -279,7 +279,12 @@ void spi_slave(
     uint32_t out_word;
 
 	/* Enable fast mode and high priority */
+#if HIL_IO_SPI_SLAVE_HIGH_PRIO
     local_thread_mode_set_bits(thread_mode_high_priority);
+#endif
+#if HIL_IO_SPI_SLAVE_FAST_MODE
+    local_thread_mode_set_bits(thread_mode_fast);
+#endif
 
     /* Setup the chip select port */
     port_enable(p_cs);


### PR DESCRIPTION
https://github.com/xmos/sw_xvf3800/issues/317

I've made both high priority and fast mode as configurable options and set the defines enabling both to 1 by default so that the existing RTOS tests don't need to change.
For xvf3800 I've kept the spi slave as high priority but not fast mode and the xvf3800 tests pass with this configuration.