### PR TITLE
Fix test_i2s_basic_master and test_basic_master_external_clock

### DIFF
--- a/test/lib_i2s/i2s_master_external_clock_test/i2s_master_external_clock_test.cmake
+++ b/test/lib_i2s/i2s_master_external_clock_test/i2s_master_external_clock_test.cmake
@@ -15,6 +15,8 @@ set(APP_LINK_OPTIONS
     -report
     -target=XCORE-AI-EXPLORER
 )
+# Compile main.c which contains the i2s_callback_group_t functions in O3 mode
+set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/src/main.c  PROPERTIES COMPILE_FLAGS "-O3")
 
 #**********************
 # Tile Targets

--- a/test/lib_i2s/i2s_master_test/i2s_master_test.cmake
+++ b/test/lib_i2s/i2s_master_test/i2s_master_test.cmake
@@ -16,6 +16,9 @@ set(APP_LINK_OPTIONS
     -target=XCORE-AI-EXPLORER
 )
 
+# Compile main.c which contains the i2s_callback_group_t functions in O3 mode
+set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/src/main.c  PROPERTIES COMPILE_FLAGS "-O3")
+
 #**********************
 # Tile Targets
 #**********************

--- a/test/lib_i2s/test_basic_master_external_clock.py
+++ b/test/lib_i2s/test_basic_master_external_clock.py
@@ -16,12 +16,6 @@ num_in_out_args = {
 
 bitdepth_args = {"16b": 16, "32b": 32}
 
-# 16b 4i4o (8ch in/8ch out) currently does not pass
-def uncollect_if(bitdepth, num_in, num_out):
-    if bitdepth == 16 and num_in == 4 and num_out == 4:
-        return True
-
-#@pytest.mark.uncollect_if(func=uncollect_if)
 @pytest.mark.parametrize("bitdepth", bitdepth_args.values(), ids=bitdepth_args.keys())
 @pytest.mark.parametrize(
     ("num_in", "num_out"), num_in_out_args.values(), ids=num_in_out_args.keys()

--- a/test/lib_i2s/test_basic_master_external_clock.py
+++ b/test/lib_i2s/test_basic_master_external_clock.py
@@ -21,7 +21,7 @@ def uncollect_if(bitdepth, num_in, num_out):
     if bitdepth == 16 and num_in == 4 and num_out == 4:
         return True
 
-@pytest.mark.uncollect_if(func=uncollect_if)
+#@pytest.mark.uncollect_if(func=uncollect_if)
 @pytest.mark.parametrize("bitdepth", bitdepth_args.values(), ids=bitdepth_args.keys())
 @pytest.mark.parametrize(
     ("num_in", "num_out"), num_in_out_args.values(), ids=num_in_out_args.keys()

--- a/test/lib_i2s/test_i2s_basic_master.py
+++ b/test/lib_i2s/test_i2s_basic_master.py
@@ -76,7 +76,7 @@ def test_i2s_basic_master(build, capfd, nightly, request, bitdepth, num_in, num_
                 simthreads=[clk, checker],
                 simargs=[
                     "--vcd-tracing",
-                    f"-o i2s_trace_{num_in}_{num_out}.vcd -tile tile[0] -cycles -ports -ports-detailed -cores -instructions",
+                    f"-o i2s_trace_{num_in}_{num_out}.vcd -tile tile[0] -cycles -ports -ports-detailed -cores -instructions -clock-blocks",
                     "--trace-to",
                     f"i2s_trace_{num_in}_{num_out}.txt",
                 ],


### PR DESCRIPTION
https://xmosjira.atlassian.net/browse/AP-403

Changes in this PR:
- Fix test_i2s_basic_master and test_basic_master_external_clock tests so they run for 192KHz, 96KHz and 48KHz for both 32bits and 16bits for the smoke test and 192, 96, 48, 176.4, 88.2 and 44.1KHz for 32 and 16bits for the nightly test.

pytest lib_i2s/test_i2s_basic_master.py
pytest lib_i2s/test_basic_master_external_clock.py

pytest lib_i2s/test_i2s_basic_master.py --nightly
pytest lib_i2s/test_basic_master_external_clock.py --nightly

Note that the mclk frequency is set such that the mclk_bclk_ratio is atleast 2 for the worst case (192KHz). I could not get the test to pass reliably if testing with mclk_bclk_ratio set to 1. Sometimes, the bclk clock block would start with a falling edge instead of a rising edge, causing the LR clk to start before the bclk.
With mclk_bclk_ratio of 2 or more, I couldn't recreate this issue. 

